### PR TITLE
Change granule size to double the size of a capability

### DIFF
--- a/include/gc_tiny_fl.h
+++ b/include/gc_tiny_fl.h
@@ -52,11 +52,13 @@
         || defined(__alpha__) || defined(__powerpc64__) \
         || defined(__arch64__) \
         || (defined(__riscv) && __riscv_xlen == 64)
-#  if defined(__CHERI_PURE_CAPABILITY__)
-#    error FIXME Expand Granule size and subsequent uses for pointer sizes being different from word sizes
-#  endif
-#  define GC_GRANULE_BYTES 16
-#  define GC_GRANULE_WORDS 2
+#  if __CHERI_CAPABILITY_WIDTH__ == 128
+#   define GC_GRANULE_BYTES 32
+#   define GC_GRANULE_WORDS 2
+#  else /* defined(__CHERI_PURE_CAPABILITY__) */
+#   define GC_GRANULE_BYTES 16
+#   define GC_GRANULE_WORDS 2
+#  endif /* defined(__CHERI_PURE_CAPABILITY__) */
 # else
 #  define GC_GRANULE_BYTES 8
 #  define GC_GRANULE_WORDS 2

--- a/include/gc_tiny_fl.h
+++ b/include/gc_tiny_fl.h
@@ -76,7 +76,7 @@
 /* containing objects i granules in size.  Note that there is a list    */
 /* of size zero objects.                                                */
 #ifndef GC_TINY_FREELISTS
-# if GC_GRANULE_BYTES == 16
+# if GC_GRANULE_BYTES == 16 || GC_GRANULE_BYTES == 32
 #   define GC_TINY_FREELISTS 25
 # else
 #   define GC_TINY_FREELISTS 33 /* Up to and including 256 bytes */

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2914,10 +2914,12 @@ EXTERN_C_BEGIN
 
 # ifdef RISCV
 #   define MACH_TYPE "RISC-V"
-#   define CPP_WORDSZ __riscv_xlen /* 32 or 64 */
 #   if defined(__CHERI_PURE_CAPABILITY__)
+#     define INTEGER_WORDSZ __riscv_xlen /* 32 or 64 */
+#     define CPP_WORDSZ __riscv_clen /* 64 or 128 */
 #     define ALIGNMENT (__riscv_clen >> 3)
 #   else 
+#     define CPP_WORDSZ __riscv_xlen /* 32 or 64 */
 #     define ALIGNMENT (CPP_WORDSZ/8)
 #   endif
 #   ifdef FREEBSD
@@ -3122,7 +3124,7 @@ EXTERN_C_BEGIN
 #if defined(CPPCHECK)
 # undef CPP_WORDSZ
 # define CPP_WORDSZ (__SIZEOF_POINTER__ * 8)
-#elif CPP_WORDSZ != 32 && CPP_WORDSZ != 64
+#elif CPP_WORDSZ != 32 && CPP_WORDSZ != 64 && CPP_WORDSZ != 128
 #   error Bad word size
 #endif
 


### PR DESCRIPTION
Granules are assumed to be double the size of a capability in BoehmGC. 
Doubling the granule size  affects  macros used in 
1. data layout of mark bits
2. Integer arithmetic for pointers 