### PR TITLE
Set word-size to cap-width for capability systems.

### DIFF
--- a/include/gc_tiny_fl.h
+++ b/include/gc_tiny_fl.h
@@ -52,11 +52,13 @@
         || defined(__alpha__) || defined(__powerpc64__) \
         || defined(__arch64__) \
         || (defined(__riscv) && __riscv_xlen == 64)
-#  if defined(__CHERI_PURE_CAPABILITY__)
-#    error FIXME Expand Granule size and subsequent uses for pointer sizes being different from word sizes
-#  endif
-#  define GC_GRANULE_BYTES 16
-#  define GC_GRANULE_WORDS 2
+#  if __CHERI_CAPABILITY_WIDTH__ == 128
+#   define GC_GRANULE_BYTES 16
+#   define GC_GRANULE_WORDS 1
+#  else /* __CHERI_CAPABILITY_WIDTH__ == 128 */
+#   define GC_GRANULE_BYTES 16
+#   define GC_GRANULE_WORDS 2
+#  endif /* __CHERI_CAPABILITY_WIDTH__ == 128 */
 # else
 #  define GC_GRANULE_BYTES 8
 #  define GC_GRANULE_WORDS 2

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -856,27 +856,23 @@ EXTERN_C_BEGIN
 #endif
 
 #if CPP_WORDSZ == 64
-#  if defined(__CHERI_PURE_CAPABILITY__) 
-#    if __CHERI_CAPABILITY_WIDTH__ == 128
-#      define WORDS_TO_BYTES(x)   ((x)<<4)
-#      define BYTES_TO_WORDS(x)   ((x)>>4)
-#      define LOGWL               ((word)7)    /* log[2] of CPP_WORDSZ */
-#      define modWORDSZ(n) ((n) & 0x7f)        /* n mod size of word            */
-#      if ALIGNMENT != 16
-#        define UNALIGNED_PTRS
-#      endif
-#    else 
-#      error Unsupported Capability Width
-#    endif 
-#  elif
-#    define WORDS_TO_BYTES(x)   ((x)<<3)
-#    define BYTES_TO_WORDS(x)   ((x)>>3)
-#    define LOGWL               ((word)6)    /* log[2] of CPP_WORDSZ */
-#    define modWORDSZ(n) ((n) & 0x3f)        /* n mod size of word            */
-#    if ALIGNMENT != 8
-#      define UNALIGNED_PTRS
-#    endif
-#  endif
+# define WORDS_TO_BYTES(x)   ((x)<<3)
+# define BYTES_TO_WORDS(x)   ((x)>>3)
+# define LOGWL               ((word)6)    /* log[2] of CPP_WORDSZ */
+# define modWORDSZ(n) ((n) & 0x3f)        /* n mod size of word            */
+# if ALIGNMENT != 8
+#   define UNALIGNED_PTRS
+# endif
+#endif
+
+#if CPP_WORDSZ == 128
+# define WORDS_TO_BYTES(x)   ((x)<<4)
+# define BYTES_TO_WORDS(x)   ((x)>>4)
+# define LOGWL               ((word)7)    /* log[2] of CPP_WORDSZ */
+# define modWORDSZ(n) ((n) & 0x7f)        /* n mod size of word            */
+# if ALIGNMENT != 16
+#   define UNALIGNED_PTRS
+# endif
 #endif
 
 /* The first TINY_FREELISTS free lists correspond to the first  */
@@ -889,7 +885,11 @@ EXTERN_C_BEGIN
 #define TINY_FREELISTS GC_TINY_FREELISTS
 
 #define WORDSZ ((word)CPP_WORDSZ)
-#define SIGNB  ((word)1 << (WORDSZ-1))
+#if defined(__CHERI_PURE_CAPABILITY__)
+# define SIGNB  ((word)1 << (INTEGER_WORDSZ-1))
+#else  /* defined(__CHERI_PURE_CAPABILITY__) */
+# define SIGNB  ((word)1 << (WORDSZ-1))
+#endif /* defined(__CHERI_PURE_CAPABILITY__) */
 #define BYTES_PER_WORD      ((word)(sizeof (word)))
 #define divWORDSZ(n) ((n) >> LOGWL)     /* divide n by size of word */
 

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2914,10 +2914,12 @@ EXTERN_C_BEGIN
 
 # ifdef RISCV
 #   define MACH_TYPE "RISC-V"
-#   define CPP_WORDSZ __riscv_xlen /* 32 or 64 */
 #   if defined(__CHERI_PURE_CAPABILITY__)
+#     define INTEGER_WORDSZ __riscv_xlen /* 32 or 64 */
+#     define CPP_WORDSZ __riscv_clen /* 64 or 128 */
 #     define ALIGNMENT (__riscv_clen >> 3)
-#   else 
+#   else
+#     define CPP_WORDSZ __riscv_xlen /* 32 or 64 */
 #     define ALIGNMENT (CPP_WORDSZ/8)
 #   endif
 #   ifdef FREEBSD
@@ -3122,7 +3124,7 @@ EXTERN_C_BEGIN
 #if defined(CPPCHECK)
 # undef CPP_WORDSZ
 # define CPP_WORDSZ (__SIZEOF_POINTER__ * 8)
-#elif CPP_WORDSZ != 32 && CPP_WORDSZ != 64
+#elif CPP_WORDSZ != 32 && CPP_WORDSZ != 64 && CPP_WORDSZ != 128
 #   error Bad word size
 #endif
 


### PR DESCRIPTION
Capability width is different to Integer width for capability systems.
(e.g. 128-bit capability systems will only have a 64-bit integer
register). Capabilites should only be dereferenced at the correct alignment.
Integer arithmetic (e.g. checking for MAX conditions) should take the width
of registers used for arithmetic operations and not the whole size of a
capability.