### PR TITLE
Correct Mark-bit calculations and ensure capabilities are dereferenced only at aligned locations

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -868,8 +868,12 @@ EXTERN_C_BEGIN
 #if CPP_WORDSZ == 128
 # define WORDS_TO_BYTES(x)   ((x)<<4)
 # define BYTES_TO_WORDS(x)   ((x)>>4)
-# define LOGWL               ((word)7)    /* log[2] of CPP_WORDSZ */
-# define modWORDSZ(n) ((n) & 0x7f)        /* n mod size of word            */
+# if defined(__CHERI_PURE_CAPABILITY__)
+#   define LOGCL             ((word)7)    /* log[2] of CPP_WORDSZ */
+#   define modCAPSZ(n)       ((n) & 0x7f) /* n mod size of capability      */
+# endif
+# define LOGWL               ((word)6)    /* log[2] of INTEGER_WORDSZ */
+# define modWORDSZ(n) ((n) & 0x3f)        /* n mod size of word            */
 # if ALIGNMENT != 16
 #   define UNALIGNED_PTRS
 # endif
@@ -887,11 +891,12 @@ EXTERN_C_BEGIN
 #define WORDSZ ((word)CPP_WORDSZ)
 #if defined(__CHERI_PURE_CAPABILITY__)
 # define SIGNB  ((word)1 << (INTEGER_WORDSZ-1))
+# define BYTES_PER_WORD      ((word)(sizeof (word *)))
 #else  /* defined(__CHERI_PURE_CAPABILITY__) */
 # define SIGNB  ((word)1 << (WORDSZ-1))
+# define BYTES_PER_WORD      ((word)(sizeof (word)))
 #endif /* defined(__CHERI_PURE_CAPABILITY__) */
-#define BYTES_PER_WORD      ((word)(sizeof (word)))
-#define divWORDSZ(n) ((n) >> LOGWL)     /* divide n by size of word */
+# define divWORDSZ(n) ((n) >> LOGWL)     /* divide n by size of word */
 
 #if GRANULE_BYTES == 8
 # define BYTES_TO_GRANULES(n) ((n)>>3)
@@ -1202,7 +1207,11 @@ struct hblkhdr {
       } _mark_byte_union;
 #     define hb_marks _mark_byte_union._hb_marks
 #   else
-#     define MARK_BITS_SZ (MARK_BITS_PER_HBLK/CPP_WORDSZ + 1)
+#     if defined(__CHERI_PURE_CAPABILITY__)
+#       define MARK_BITS_SZ (MARK_BITS_PER_HBLK/INTEGER_WORDSZ + 1)
+#     else  /* defined(__CHERI_PURE_CAPABILITY__) */
+#       define MARK_BITS_SZ (MARK_BITS_PER_HBLK/CPP_WORDSZ + 1)
+#     endif  /* defined(__CHERI_PURE_CAPABILITY__) */
       word hb_marks[MARK_BITS_SZ];
 #   endif /* !USE_MARK_BYTES */
 };

--- a/reclaim.c
+++ b/reclaim.c
@@ -158,7 +158,7 @@ GC_INLINE word *GC_clear_block(word *p, word sz, signed_word *count)
       p += 2;
     }
 # else
-    p++; /* Skip link field */
+    p = (ptr_t)p + sizeof(word *); /* Skip link field */
     while ((word)p < (word)q) {
       *p++ = 0;
     }
@@ -395,7 +395,11 @@ STATIC void GC_reclaim_block(struct hblk *hbp, word report_if_found)
     if( sz > MAXOBJBYTES ) {  /* 1 big object */
         if( !mark_bit_from_hdr(hhdr, 0) ) {
             if (report_if_found) {
-              GC_add_leaked((ptr_t)hbp);
+#             if defined(__CHERI_PURE_CAPABILITY__)
+                GC_add_leaked((ptr_t)(hhdr->hb_block));
+#             else
+                GC_add_leaked((ptr_t)hbp);
+#             endif
             } else {
               word blocks;
 
@@ -416,7 +420,11 @@ STATIC void GC_reclaim_block(struct hblk *hbp, word report_if_found)
                 GC_large_allocd_bytes -= blocks * HBLKSIZE;
               }
               GC_bytes_found += sz;
-              GC_freehblk(hbp);
+#             if defined(__CHERI_PURE_CAPABILITY__)
+                GC_freehblk(hhdr->hb_block);
+#             else
+                GC_freehblk(hbp);
+#             endif
             }
         } else {
 #        ifdef ENABLE_DISCLAIM
@@ -447,12 +455,20 @@ STATIC void GC_reclaim_block(struct hblk *hbp, word report_if_found)
         } else if (empty) {
 #       ifdef ENABLE_DISCLAIM
           if ((hhdr -> hb_flags & HAS_DISCLAIM) != 0) {
-            GC_disclaim_and_reclaim_or_free_small_block(hbp);
+#           if defined(__CHERI_PURE_CAPABILITY__)
+              GC_disclaim_and_reclaim_or_free_small_block(hhdr->hb_block);
+#           else
+              GC_disclaim_and_reclaim_or_free_small_block(hbp);
+#           endif
           } else
 #       endif
           /* else */ {
             GC_bytes_found += HBLKSIZE;
+#       if defined(__CHERI_PURE_CAPABILITY__)
+            GC_freehblk(hhdr->hb_block);
+#       else
             GC_freehblk(hbp);
+#       endif
           }
         } else if (GC_find_leak || !GC_block_nearly_full(hhdr, sz)) {
           /* group of smaller objects, enqueue the real work */
@@ -461,7 +477,11 @@ STATIC void GC_reclaim_block(struct hblk *hbp, word report_if_found)
           if (rlh != NULL) {
             rlh += BYTES_TO_GRANULES(sz);
             hhdr -> hb_next = *rlh;
-            *rlh = hbp;
+#           if defined(__CHERI_PURE_CAPABILITY__)
+              *rlh = hhdr -> hb_block;
+#           else
+              *rlh = hbp;
+#           endif
           }
         } /* else not worth salvaging. */
         /* We used to do the nearly_full check later, but we    */
@@ -648,7 +668,7 @@ GC_INNER void GC_start_reclaim(GC_bool report_if_found)
             void **lim = &(GC_obj_kinds[kind].ok_freelist[MAXOBJGRANULES+1]);
 
             for (fop = GC_obj_kinds[kind].ok_freelist;
-                 (word)fop < (word)lim; (*(word **)&fop)++) {
+                 (word)fop < (word)lim; fop++) {
               if (*fop != 0) {
                 if (should_clobber) {
                   GC_clear_fl_links(fop);


### PR DESCRIPTION
1. In  *CHERI* systems,utilize the capability pointer to an *hblk*  from its header rather than the arithmetically derived pointer addresss. 
2. Mark-bits arithmetic should utilise  *xlen*(integer size)  instead of *clen* (capability size)
3. During GC,  pointer  increments and derivations should be done with capability size vs  *word* size