### PR TITLE
Prevent coalescing during remapping and unmapping if bounds are not large enough.

### DIFF
--- a/allchblk.c
+++ b/allchblk.c
@@ -532,6 +532,11 @@ GC_INNER void GC_merge_unmapped(void)
         /* Coalesce with successor, if possible */
           if (0 != nexthdr && HBLK_IS_FREE(nexthdr)
               && (signed_word) (size + (nextsize = nexthdr->hb_sz)) > 0
+#           if defined(__CHERI_PURE_CAPABILITY__)
+              /* CVMFIXME : coalesce with super-capability */
+              && (cheri_base_get(h) <= cheri_address_get(next))
+              && (cheri_base_get(h) + cheri_length_get(h)) >= (cheri_address_get(next) + nextsize)
+#           endif
                  /* no pot. overflow */) {
             /* Note that we usually try to avoid adjacent free blocks   */
             /* that are either both mapped or both unmapped.  But that  */
@@ -969,6 +974,7 @@ GC_INNER void GC_freehblk(struct hblk *hbp)
       if(0 != nexthdr && HBLK_IS_FREE(nexthdr) && IS_MAPPED(nexthdr)
          && (signed_word)(hhdr -> hb_sz + nexthdr -> hb_sz) > 0
 #     if defined(__CHERI_PURE_CAPABILITY__)
+         /* CVMFIXME : coalesce with super-capability */
          /* Bounds of capability should span entire coalesced memory */
          /* Bounds being larger than blk-size is OK; bounded by the imprecision */
          /* of original capability obtained from system memory */
@@ -986,6 +992,7 @@ GC_INNER void GC_freehblk(struct hblk *hbp)
         if (IS_MAPPED(prevhdr)
             && (signed_word)(hhdr -> hb_sz + prevhdr -> hb_sz) > 0
 #       if defined(__CHERI_PURE_CAPABILITY__)
+            /* CVMFIXME : coalesce with super-capability */
             && (cheri_base_get(hbp) <= cheri_address_get(prev))
 #       endif
             /* no overflow */ ) {

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -85,5 +85,4 @@ run()
 setup
 
 # Execute 
-run OK "bdwgc_install/bin/small_fixed_alloc.elf"
-run to_fail "bdwgc_install/bin/random_mixed_alloc.elf"
+run OK "bdwgc_install/bin/small_fixed_alloc.elf" "bdwgc_install/bin/random_mixed_alloc.elf"

--- a/headers.c
+++ b/headers.c
@@ -355,9 +355,13 @@ GC_INNER struct hblk * GC_next_block(struct hblk *h, GC_bool allow_free)
                 j++;
             } else {
                 if (allow_free || !HBLK_IS_FREE(hhdr)) {
+#                 if !defined(__CHERI_PURE_CAPABILITY__)
                     return ((struct hblk *)
                               (((bi -> key << LOG_BOTTOM_SZ) + j)
                                << LOG_HBLKSIZE));
+#                 else
+                    return((struct hblk *)hhdr->hb_block);
+#                 endif
                 } else {
                     j += divHBLKSZ(hhdr -> hb_sz);
                 }
@@ -390,13 +394,13 @@ GC_INNER struct hblk * GC_prev_block(struct hblk *h)
             } else if (IS_FORWARDING_ADDR_OR_NIL(hhdr)) {
                 j -= (signed_word)hhdr;
             } else {
-	      #if !defined(__CHERI_PURE_CAPABILITY__)
+#             if !defined(__CHERI_PURE_CAPABILITY__)
                 return((struct hblk *)
                           (((bi -> key << LOG_BOTTOM_SZ) + j)
                                << LOG_HBLKSIZE));
-	      #else
+#             else
                 return((struct hblk *)hhdr->hb_block);
-	      #endif
+#             endif
             }
         }
         j = BOTTOM_SZ - 1;


### PR DESCRIPTION
BDWGC attempts to coalesce memory within it's heap map  by toggling the *mapped* status of memory and appending to adjacent free memory with the opposite map status. Doing this in CHERI architectures causes the loss of a capability with which to dereference the memory chunk which was merged into the larger chunk. 
Only allow coalescing if the bounds of the  resulting capability spans the the entire coalesced memory. 
