### PR TITLE
Check capability tags of derived pointers before pushing to mark-stack.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "building for riscv64-purecap"
 CHERIBUILD=~/build
-PLATFORMS='riscv64-purecap'
 
 export SSHPORT=10021
 export SSHHOST=localhost
@@ -50,27 +48,58 @@ clean()
     rm -rf ${@}
 }
 
-echo "Checking bdwgc library builds correctly"
-build_bdwgc ${PLATFORMS}
-echo "Checking cheri bdwgc clients build correctly"
-build_bdwgc_clients ${PLATFORMS}
 
-echo "Running tests for riscv64-purecap"
-args=(
-    --architecture riscv64-purecap
-    # Qemu System to use
-    --qemu-cmd $HOME/cheri/output/sdk/bin/qemu-system-riscv64cheri
-    # Kernel (to avoid the default one) 
-    --kernel $HOME/cheri/output/rootfs-riscv64-purecap/boot/kernel/kernel
-    # Bios (to avoid the default one) 
-    --bios bbl-riscv64cheri-virt-fw_jump.bin
-    --disk-image $HOME/cheri/output/cheribsd-riscv64-purecap.img
-    # Required build-dir in CheriBSD
-    --build-dir .
-    --ssh-port $SSHPORT
-    --ssh-key $HOME/.ssh/id_ed25519.pub
-    )
-BUILDBOT_PLATFORM=riscv64-purecap python3 ci/run_cheri_bdwgc_tests.py "${args[@]}"
+if [ "$1" = "riscv64" ]; then
+    echo "Checking bdwgc library builds correctly"
+    build_bdwgc 'riscv64-purecap'
 
-echo "removing up unit-test files" 
-clean bdwgc_build bdwgc_client_build bdwgc_install
+    echo "Checking cheri bdwgc clients build correctly"
+    build_bdwgc_clients 'riscv64-purecap'
+
+    echo "Running tests for riscv64-purecap"
+    args=(
+        --architecture riscv64-purecap
+        # Qemu System to use
+        --qemu-cmd $HOME/cheri/output/sdk/bin/qemu-system-riscv64cheri
+        # Kernel (to avoid the default one)
+        --kernel $HOME/cheri/output/rootfs-riscv64-purecap/boot/kernel/kernel
+        # Bios (to avoid the default one)
+        --bios bbl-riscv64cheri-virt-fw_jump.bin
+        --disk-image $HOME/cheri/output/cheribsd-riscv64-purecap.img
+        # Required build-dir in CheriBSD
+        --build-dir .
+        --ssh-port $SSHPORT
+        --ssh-key $HOME/.ssh/id_ed25519.pub
+        )
+    BUILDBOT_PLATFORM=riscv64-purecap python3 ci/run_cheri_bdwgc_tests.py "${args[@]}"
+
+    echo "removing up unit-test files"
+    clean bdwgc_build bdwgc_client_build bdwgc_install
+
+elif [ "$1" = "morello-purecap" ]; then
+    echo "Checking bdwgc library builds correctly"
+    build_bdwgc 'morello-purecap'
+
+    echo "Checking cheri bdwgc clients build correctly"
+    build_bdwgc_clients 'morello-purecap'
+
+    echo "Running tests for morello-purecap"
+    args=(
+        --architecture morello-purecap
+        # Qemu System to use
+        --qemu-cmd $HOME/cheri/output/morello-sdk/bin/qemu-system-morello
+        # Kernel (to avoid the default one)
+        --kernel $HOME/cheri/output/rootfs-morello-purecap/boot/kernel/kernel
+        # Bios (to avoid the default one)
+        --bios edk2-aarch64-code.fd
+        --disk-image $HOME/cheri/output/cheribsd-morello-purecap.img
+        # Required build-dir in CheriBSD
+        --build-dir .
+        --ssh-port $SSHPORT
+        --ssh-key $HOME/.ssh/id_ed25519.pub
+        )
+    BUILDBOT_PLATFORM=morello-purecap python3 ci/run_cheri_bdwgc_tests.py "${args[@]}"
+
+    echo "removing up unit-test files"
+    clean bdwgc_build bdwgc_client_build bdwgc_install
+fi

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = ["buildbot/capablevms-test-script"]
 
-timeout_sec = 600 # 10 minutes
+timeout_sec = 1800 # 30 minutes
 
 # Have bors delete auto-merged branches
 delete_merged_branches = true

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -69,13 +69,13 @@ run()
         if [ "$1" = "to_fail" ]; then
             exit_status=0
             RESULT={{$(ssh -o "StrictHostKeyChecking no" -p ${SSHPORT} root@${SSHHOST} -t \
-	                   "setenv LD_LIBRARY_PATH /root && ./$(basename ${name})")} && exit_status=1} || true
+	                   "LD_LIBRARY_PATH=/root:\$\{LD_LIBRARY_PATH\} ./$(basename ${name})")} && exit_status=1} || true
             if [ $exit_status != 0 ]; then
                 exit 1
             fi
         else
             ssh -o "StrictHostKeyChecking no" -p ${SSHPORT} root@${SSHHOST} -t \
-	                   "setenv LD_LIBRARY_PATH /root && ./$(basename ${name})"
+	                   "LD_LIBRARY_PATH=/root:\$\{LD_LIBRARY_PATH\} ./$(basename ${name})"
         fi
     done
 
@@ -85,4 +85,6 @@ run()
 setup
 
 # Execute 
-run OK "bdwgc_install/bin/small_fixed_alloc.elf" "bdwgc_install/bin/random_mixed_alloc.elf"
+run OK "bdwgc_install/bin/small_fixed_alloc.elf" \
+       "bdwgc_install/bin/random_mixed_alloc.elf" \
+       "bdwgc_install/bin/binary_tree.elf"

--- a/ci/tests/CMakeLists.txt
+++ b/ci/tests/CMakeLists.txt
@@ -8,7 +8,9 @@ project(BoehmGC
 include_directories(AFTER ${CMAKE_INSTALL_PREFIX}/include) 
 add_executable(random_mixed_alloc.elf random_mixed_alloc.c)
 add_executable(small_fixed_alloc.elf small_fixed_alloc.c)
+add_executable(binary_tree.elf binary_tree.c)
 target_link_libraries(random_mixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(small_fixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+target_link_libraries(binary_tree.elf libm.so libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 
-install(TARGETS random_mixed_alloc.elf small_fixed_alloc.elf  RUNTIME DESTINATION bin) 
+install(TARGETS random_mixed_alloc.elf small_fixed_alloc.elf  binary_tree.elf RUNTIME DESTINATION bin)

--- a/ci/tests/binary_tree.c
+++ b/ci/tests/binary_tree.c
@@ -1,0 +1,144 @@
+/*! 
+This is a specific instance of the Open Source Initiative (OSI) BSD license template
+http://www.opensource.org/licenses/bsd-license.php
+
+Copyright © 2004-2008 Brent Fulgham, 2005-2019 Isaac Gouy
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* The Computer Language Benchmarks Game
+ * https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+
+ contributed by Kevin Carson
+ compilation:
+     gcc -O3 -fomit-frame-pointer -funroll-loops -static binary-trees.c -lm
+     icc -O3 -ip -unroll -static binary-trees.c -lm
+
+ *reset*
+*/
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#if defined(__CHERI_PURE_CAPABILITY__)
+#include <cheriintrin.h>
+#endif
+#include "gc.h"
+
+#define DEFAULT_DEPTH 16
+
+typedef struct tn {
+  struct tn *left;
+  struct tn *right;
+} treeNode;
+
+
+treeNode* NewTreeNode(treeNode* left, treeNode* right)
+{
+  treeNode *new;
+  static int alloc_count = 0;
+
+  new = (treeNode *)GC_MALLOC(sizeof(treeNode));
+
+  new->left = left;
+  new->right = right;
+  return new;
+} /* NewTreeNode() */
+
+
+long ItemCheck(treeNode* tree)
+{
+  if (tree->left == NULL) {
+    return 1;
+  } else {
+    return 1 + ItemCheck(tree->left) + ItemCheck(tree->right);
+  }
+} /* ItemCheck() */
+
+
+treeNode* BottomUpTree(unsigned depth)
+{
+  if (depth > 0)
+      return NewTreeNode(BottomUpTree(depth - 1), BottomUpTree(depth - 1));
+  else
+      return NewTreeNode(NULL, NULL);
+} /* BottomUpTree() */
+
+
+void DeleteTree(treeNode* tree)
+{
+  if (tree->left != NULL)
+  {
+      DeleteTree(tree->left);
+      DeleteTree(tree->right);
+  }
+
+  // To be performed by GC
+  // free(tree);
+} /* DeleteTree() */
+
+int main(int argc, char* argv[])
+{
+  unsigned   N, depth, minDepth, maxDepth, stretchDepth;
+  treeNode   *stretchTree, *longLivedTree, *tempTree;
+
+  GC_INIT();
+
+  /* check we have an argument */
+  if (argc < 2) {
+    printf("Usage: %s <depth-of-tree>\ndefaulting to depth %u\n " , argv[0], DEFAULT_DEPTH);
+    N = DEFAULT_DEPTH;
+  } else {
+    N = atol(argv[1]);
+  }
+
+  minDepth = 4;
+  maxDepth = ((minDepth + 2) > N) ?  minDepth + 2 : N;
+  stretchDepth = maxDepth + 1;
+
+  stretchTree = BottomUpTree(stretchDepth);
+  printf("stretch tree of depth %u\t check: %li\n", stretchDepth, ItemCheck(stretchTree));
+
+  DeleteTree(stretchTree);
+
+  longLivedTree = BottomUpTree(maxDepth);
+
+  for (depth = minDepth; depth <= maxDepth; depth += 2)
+  {
+    long    i, iterations, check;
+    iterations = pow(2, maxDepth - depth + minDepth);
+    check = 0;
+
+    for (i = 1; i <= iterations; i++) {
+      tempTree = BottomUpTree(depth);
+      check += ItemCheck(tempTree);
+      DeleteTree(tempTree);
+    } /* for(i = 1...) */
+
+    printf("%li\t trees of depth %u\t check: %li\n", iterations, depth, check);
+  } /* for(depth = minDepth...) */
+
+  printf("long lived tree of depth %u\t check: %li\n", maxDepth, ItemCheck(longLivedTree));
+  return 0;
+} /* main() */


### PR DESCRIPTION
During scanning, pointers within stack memory regions
can be partially over-written by newer frames invalidating old
pointer references.  As these invalidated pointers cannot be de-referenced,
the memory they point to should NOT be marked. (in case other valid pointers
to the same memory location are yet to be scanned). If they are already
marked, the second (valid) pointer will not get pushed onto the mark
stack.