### PR TITLE
Utilize stored capability if reporting during reclaiming of free blocks

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -30,7 +30,9 @@ build_bdwgc()
 add_bdwgc_test_suite()
 {
     SRC_DIR=ci/tests
-    BDWGC_TEST_FILES="smash.c"
+    BDWGC_TEST_FILES="smash.c \
+                      leak.c  \
+                      huge.c"
     for src_file in ${BDWGC_TEST_FILES}; do
         ln -fs ../../tests/${src_file} ${SRC_DIR}/${src_file}
     done
@@ -59,7 +61,9 @@ clean()
     rm -rf ${@}
 
     SRC_DIR=ci/tests
-    BDWGC_TEST_FILES="smash.c"
+    BDWGC_TEST_FILES="smash.c \
+                      leak.c  \
+                      huge.c"
 
     for src_file in ${BDWGC_TEST_FILES}; do
         rm ${SRC_DIR}/${src_file}

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -62,7 +62,7 @@ run()
         if [ $? -ne 0 ]; then 
             echo "Error copying unit-test executable ${name} to ${BUILDBOT_PLATFORM} VM"
             exit 1
-        fi 	
+        fi
 
         # These tests should trigger an "In-address space security exception"
         # So they should fail, i.e. `exit=1`
@@ -87,5 +87,7 @@ setup
 # Execute 
 run OK "bdwgc_install/bin/small_fixed_alloc.elf"  \
        "bdwgc_install/bin/random_mixed_alloc.elf" \
-       "bdwgc_install/bin/binary_tree.elf"        \
-       "bdwgc_install/bin/smash_test.elf"
+       "bdwgc_install/bin/huge.elf"               \
+       "bdwgc_install/bin/smash_test.elf"         \
+       "bdwgc_install/bin/leak.elf"               \
+       "bdwgc_install/bin/binary_tree.elf"

--- a/ci/tests/CMakeLists.txt
+++ b/ci/tests/CMakeLists.txt
@@ -10,13 +10,19 @@ add_executable(random_mixed_alloc.elf random_mixed_alloc.c)
 add_executable(small_fixed_alloc.elf small_fixed_alloc.c)
 add_executable(binary_tree.elf binary_tree.c)
 add_executable(smash_test.elf smash.c)
+add_executable(huge.elf huge.c)
+add_executable(leak.elf leak.c)
 target_link_libraries(random_mixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(small_fixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(binary_tree.elf libm.so libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+target_link_libraries(huge.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(smash_test.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+target_link_libraries(leak.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 
 install(TARGETS random_mixed_alloc.elf
                 small_fixed_alloc.elf
                 binary_tree.elf
+                huge.elf
                 smash_test.elf
+                leak.elf
                 RUNTIME DESTINATION bin)

--- a/dbg_mlc.c
+++ b/dbg_mlc.c
@@ -290,8 +290,13 @@ GC_INNER void *GC_store_debug_info_inner(void *p, word sz GC_ATTR_UNUSED,
 #   ifndef SHORT_DBG_HDRS
       ((oh *)p) -> oh_sz = sz;
       ((oh *)p) -> oh_sf = START_FLAG ^ (word)result;
-      ((word *)p)[BYTES_TO_WORDS(GC_size(p))-1] =
-         result[SIMPLE_ROUNDED_UP_WORDS(sz)] = END_FLAG ^ (word)result;
+#     if defined(__CHERI_PURE_CAPABILITY__)
+        ((word *)p)[BYTES_TO_INTEGERS(GC_size(p))-1] =
+           result[SIMPLE_ROUNDED_UP_WORDS(sz)] = END_FLAG ^ (word)result;
+#     else
+        ((word *)p)[BYTES_TO_WORDS(GC_size(p))-1] =
+           result[SIMPLE_ROUNDED_UP_WORDS(sz)] = END_FLAG ^ (word)result;
+#     endif
 #   endif
     return result;
 }

--- a/include/private/dbg_mlc.h
+++ b/include/private/dbg_mlc.h
@@ -120,7 +120,11 @@ typedef struct {
 #endif
 
 /* Round bytes to words without adding extra byte at end.       */
-#define SIMPLE_ROUNDED_UP_WORDS(n) BYTES_TO_WORDS((n) + WORDS_TO_BYTES(1) - 1)
+#if defined(__CHERI_PURE_CAPABILITY__)
+#  define SIMPLE_ROUNDED_UP_WORDS(n) BYTES_TO_INTEGERS((n) + INTEGERS_TO_BYTES(1) - 1)
+#else
+#  define SIMPLE_ROUNDED_UP_WORDS(n) BYTES_TO_WORDS((n) + WORDS_TO_BYTES(1) - 1)
+#endif
 
 /* ADD_CALL_CHAIN stores a (partial) call chain into an object  */
 /* header; it should be called with the allocation lock held.   */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -883,6 +883,8 @@ EXTERN_C_BEGIN
 # if defined(__CHERI_PURE_CAPABILITY__)
 #   define LOGCL             ((word)7)    /* log[2] of CPP_WORDSZ */
 #   define modCAPSZ(n)       ((n) & 0x7f) /* n mod size of capability      */
+#   define INTEGERS_TO_BYTES(x)   ((x)<<3)
+#   define BYTES_TO_INTEGERS(x)   ((x)>>3)
 # endif
 # define LOGWL               ((word)6)    /* log[2] of INTEGER_WORDSZ */
 # define modWORDSZ(n) ((n) & 0x3f)        /* n mod size of word            */

--- a/reclaim.c
+++ b/reclaim.c
@@ -457,8 +457,14 @@ STATIC void GC_reclaim_block(struct hblk *hbp, word report_if_found)
           GC_ASSERT(sz * hhdr -> hb_n_marks <= HBLKSIZE);
 #       endif
         if (report_if_found) {
-          GC_reclaim_small_nonempty_block(hbp, sz,
-                                          TRUE /* report_if_found */);
+          struct hblk *hblk_ptr;
+#         if defined(__CHERI_PURE_CAPABILITY__)
+            hblk_ptr = hhdr->hb_block;
+#         else
+            hblk_ptr = hbp;
+#         endif
+            GC_reclaim_small_nonempty_block(hblk_ptr, sz,
+                                            TRUE /* report_if_found */);
         } else if (empty) {
 #       ifdef ENABLE_DISCLAIM
           if ((hhdr -> hb_flags & HAS_DISCLAIM) != 0) {


### PR DESCRIPTION
* When using *bdwgc* for leak test checking, use a capability that can be de-referenced when collecting free blocks
* Separate macros for integer and capability aligned access. In debug builds, canary values are written into allocated memory using load-store macros that assume sizeof(int) = sizeof(int *). A separate macro is used to calculate the correct offset within a serialized data structure. This will also prevent data corruption of other fields within the debug-header.