### PR TITLE
Add richards benchmark to test suite

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -87,7 +87,8 @@ setup
 # Execute 
 run OK "bdwgc_install/bin/small_fixed_alloc.elf"  \
        "bdwgc_install/bin/random_mixed_alloc.elf" \
-       "bdwgc_install/bin/huge.elf"               \
        "bdwgc_install/bin/smash_test.elf"         \
        "bdwgc_install/bin/leak.elf"               \
-       "bdwgc_install/bin/binary_tree.elf"
+       "bdwgc_install/bin/binary_tree.elf"        \
+       "bdwgc_install/bin/huge.elf"               \
+       "bdwgc_install/bin/richards.elf"           \

--- a/ci/tests/CMakeLists.txt
+++ b/ci/tests/CMakeLists.txt
@@ -12,12 +12,14 @@ add_executable(binary_tree.elf binary_tree.c)
 add_executable(smash_test.elf smash.c)
 add_executable(huge.elf huge.c)
 add_executable(leak.elf leak.c)
+add_executable(richards.elf richards.c)
 target_link_libraries(random_mixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(small_fixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(binary_tree.elf libm.so libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(huge.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(smash_test.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 target_link_libraries(leak.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+target_link_libraries(richards.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 
 install(TARGETS random_mixed_alloc.elf
                 small_fixed_alloc.elf
@@ -25,4 +27,5 @@ install(TARGETS random_mixed_alloc.elf
                 huge.elf
                 smash_test.elf
                 leak.elf
+                richards.elf
                 RUNTIME DESTINATION bin)

--- a/ci/tests/harness.h
+++ b/ci/tests/harness.h
@@ -1,0 +1,37 @@
+/** A simple harness for the C benchmarks
+ *
+ * It is included by every benchmark file and provides the time measuring,
+ * as well as standardized command-line argument parsing.
+ *
+ *  Released under Public domain.
+ *  Author:  S. Marr  University of Kent
+ */
+
+#include <sys/time.h>
+
+unsigned long microseconds() {
+  // Not monotonic
+  struct timeval t;
+  gettimeofday(&t, NULL);
+  return (t.tv_sec * 1000 * 1000) + t.tv_usec;
+};
+
+void parse_argv(int argc,
+                char** argv,
+                int* iterations,
+                int* warmup,
+                int* inner_or_problem_size) {
+  if (argc > 1) {
+    *iterations = atoi(argv[1]);
+  }
+  if (argc > 2) {
+    *warmup     = atoi(argv[2]);
+  }
+  if (argc > 3) {
+    *inner_or_problem_size = atoi(argv[3]);
+  }
+
+  printf("Overall iterations:     %d\n", *iterations);
+  printf("Warmup  iterations:     %d\n", *warmup);
+  printf("Inner it./problem size: %d\n", *inner_or_problem_size);
+};

--- a/ci/tests/richards.c
+++ b/ci/tests/richards.c
@@ -1,0 +1,440 @@
+/*  C version of the systems programming language benchmark
+**  The original benchmark code is in the public domain. Accordingly
+**  all changes made by J.Singer to this benchmark are also released
+**  in the public domain.
+**
+**  Author:  M. J. Jordan  Cambridge Computer Laboratory.
+**
+**  Modified by:  M. Richards, Nov 1996
+**    to be ANSI C and runnable on 64 bit machines + other minor changes
+**  Modified by:  M. Richards, 20 Oct 1998
+**    made minor corrections to improve ANSI compliance (suggested
+**    by David Levine)
+**  Modified by: J. Singer, Sep 2022
+**    add support for BDWGC and uintptr_t
+**
+**  Compile with, say
+**
+**  gcc -o bench bench.c
+**
+**  or
+**
+**  gcc -o bench100 -Dbench100 bench.c  (for a version that obeys
+**                                       the main loop 100x more often)
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <string.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#include "harness.h"
+
+#define GC
+#ifdef GC
+  #include "gc.h"
+  #include "gc/gc_mark.h"
+  #define MALLOC GC_MALLOC
+#else
+  #define MALLOC malloc
+#endif // GC
+
+#ifdef bench100
+#define                Count           10000*100
+#define                Qpktcountval    2326410
+#define                Holdcountval     930563
+#else
+#define                Count           10000
+#define                Qpktcountval    23246
+#define                Holdcountval     9297
+#endif
+
+#define                TRUE            1
+#define                FALSE           0
+#define                MAXINT          32767
+
+#define                BUFSIZE         3
+#define                I_IDLE          1
+#define                I_WORK          2
+#define                I_HANDLERA      3
+#define                I_HANDLERB      4
+#define                I_DEVA          5
+#define                I_DEVB          6
+#define                PKTBIT          1
+#define                WAITBIT         2
+#define                HOLDBIT         4
+#define                NOTPKTBIT       !1
+#define                NOTWAITBIT      !2
+#define                NOTHOLDBIT      0XFFFB
+
+#define                S_RUN           0
+#define                S_RUNPKT        1
+#define                S_WAIT          2
+#define                S_WAITPKT       3
+#define                S_HOLD          4
+#define                S_HOLDPKT       5
+#define                S_HOLDWAIT      6
+#define                S_HOLDWAITPKT   7
+
+#define                K_DEV           1000
+#define                K_WORK          1001
+
+#define                DEFAULT_ITER    4
+
+struct packet
+{
+    struct packet  *p_link;
+    int             p_id;
+    int             p_kind;
+    int             p_a1;
+    char            p_a2[BUFSIZE+1];
+};
+
+struct task
+{
+    struct task    *t_link;
+    int             t_id;
+    int             t_pri;
+    struct packet  *t_wkq;
+    int             t_state;
+    struct task    *(*t_fn)(struct packet *);
+    uintptr_t       t_v1;
+    uintptr_t       t_v2;
+};
+
+char  alphabet[28] = "0ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+struct task *tasktab[11]  =  {(struct task *)10,0,0,0,0,0,0,0,0,0,0};
+struct task *tasklist    =  0;
+struct task *tcb;
+long    taskid;
+uintptr_t v1;
+uintptr_t v2;
+int     qpktcount    =  0;
+int     holdcount    =  0;
+int     tracing      =  0;
+int     layout       =  0;
+
+void append(struct packet *pkt, struct packet *ptr);
+
+void createtask(int id,
+                int pri,
+                struct packet *wkq,
+                int state,
+                struct task *(*fn)(struct packet *),
+                uintptr_t v1,
+                uintptr_t v2)
+{
+    struct task *t = (struct task *)MALLOC(sizeof(struct task));
+
+    tasktab[id] = t;
+    t->t_link   = tasklist;
+    t->t_id     = id;
+    t->t_pri    = pri;
+    t->t_wkq    = wkq;
+    t->t_state  = state;
+    t->t_fn     = fn;
+    t->t_v1     = v1;
+    t->t_v2     = v2;
+    tasklist    = t;
+}
+
+struct packet *pkt(struct packet *link, int id, int kind)
+{
+    int i;
+    struct packet *p = (struct packet *)MALLOC(sizeof(struct packet));
+
+    for (i=0; i<=BUFSIZE; i++)
+        p->p_a2[i] = 0;
+
+    p->p_link = link;
+    p->p_id = id;
+    p->p_kind = kind;
+    p->p_a1 = 0;
+    return (p);
+}
+
+void trace(char a)
+{
+   if ( --layout <= 0 )
+   {
+        printf("\n");
+        layout = 50;
+    }
+
+    printf("%c", a);
+}
+
+void schedule(int inner)
+{
+    bool _seen = false;
+    while ( tcb != 0 )
+    {
+        struct packet *pkt;
+        struct task *newtcb;
+
+        pkt=0;
+
+        switch ( tcb->t_state )
+        {
+            case S_WAITPKT:
+                pkt = tcb->t_wkq;
+                tcb->t_wkq = pkt->p_link;
+                tcb->t_state = tcb->t_wkq == 0 ? S_RUN : S_RUNPKT;
+
+            case S_RUN:
+            case S_RUNPKT:
+                taskid = tcb->t_id;
+                v1 = tcb->t_v1;
+                v2 = tcb->t_v2;
+                if (tracing) {
+                    trace(taskid+'0');
+                }
+                newtcb = (*(tcb->t_fn))(pkt);
+                tcb->t_v1 = v1;
+                tcb->t_v2 = v2;
+                tcb = newtcb;
+                break;
+
+            case S_WAIT:
+            case S_HOLD:
+            case S_HOLDPKT:
+            case S_HOLDWAIT:
+            case S_HOLDWAITPKT:
+                tcb = tcb->t_link;
+                break;
+
+            default:
+                return;
+        }
+    }
+}
+
+struct task *wait_task(void)
+{
+    tcb->t_state |= WAITBIT;
+    return (tcb);
+}
+
+struct task *holdself(void)
+{
+    ++holdcount;
+    tcb->t_state |= HOLDBIT;
+    return (tcb->t_link) ;
+}
+
+struct task *findtcb(int id)
+{
+    struct task *t = 0;
+
+    if (1<=id && id<=(long)tasktab[0])
+      t = tasktab[id];
+    if (t==0)
+      printf("\nBad task id %d\n", id);
+    return(t);
+}
+
+struct task *release(int id)
+{
+    struct task *t;
+
+    t = findtcb(id);
+    if ( t==0 ) return (0);
+
+    t->t_state &= NOTHOLDBIT;
+    if ( t->t_pri > tcb->t_pri )
+        return (t);
+
+    return (tcb) ;
+}
+
+
+struct task *qpkt(struct packet *pkt)
+{
+    struct task *t;
+
+    t = findtcb(pkt->p_id);
+    if (t==0) return (t);
+
+    qpktcount++;
+
+    pkt->p_link = 0;
+    pkt->p_id = taskid;
+
+   if (t->t_wkq==0)
+    {
+        t->t_wkq = pkt;
+        t->t_state |= PKTBIT;
+        if (t->t_pri > tcb->t_pri) return (t);
+    }
+    else
+    {
+        append(pkt, (struct packet *)&(t->t_wkq));
+    }
+
+    return (tcb);
+}
+
+struct task *idlefn(struct packet *pkt)
+{
+    if ( --v2==0 ) return ( holdself() );
+
+    if ( (v1&1) == 0 )
+    {
+        v1 = ( v1>>1) & MAXINT;
+        return ( release(I_DEVA) );
+    }
+    else
+    {
+        v1 = ( (v1>>1) & MAXINT) ^ 0XD008;
+        return ( release(I_DEVB) );
+    }
+}
+
+struct task *workfn(struct packet *pkt)
+{
+    if ( pkt==0 ) {
+        return ( wait_task() );
+    } else {
+        int i;
+
+        v1 = I_HANDLERA + I_HANDLERB - v1;
+        pkt->p_id = v1;
+
+        pkt->p_a1 = 0;
+        for (i=0; i<=BUFSIZE; i++)
+        {
+            v2++;
+            if ( v2 > 26 )
+              v2 = 1;
+            (pkt->p_a2)[i] = alphabet[v2];
+        }
+        return ( qpkt(pkt) );
+    }
+}
+
+struct task *handlerfn(struct packet *pkt)
+{
+  if ( pkt!=0) {
+    append(pkt, (struct packet *)(pkt->p_kind==K_WORK ? &v1 : &v2));
+  }
+
+  if ( v1!=0 ) {
+    int count;
+    struct packet *workpkt = (struct packet *)v1;
+    count = workpkt->p_a1;
+
+    if ( count > BUFSIZE ) {
+      v1 = (uintptr_t)(((struct packet *)v1)->p_link);
+      return ( qpkt(workpkt) );
+    }
+
+    if ( v2!=0 ) {
+      struct packet *devpkt;
+
+      devpkt = (struct packet *)v2;
+      v2 = (uintptr_t)(((struct packet *)v2)->p_link);
+      devpkt->p_a1 = workpkt->p_a2[count];
+      workpkt->p_a1 = count+1;
+      return( qpkt(devpkt) );
+    }
+  }
+  return wait_task();
+}
+
+struct task *devfn(struct packet *pkt)
+{
+    if ( pkt==0 )
+    {
+        if ( v1==0 )
+	    return ( wait_task() );
+        pkt = (struct packet *)v1;
+        v1 = 0;
+        return ( qpkt(pkt) );
+    }
+    else
+    {
+        v1 = (uintptr_t)pkt;
+        if (tracing)
+	    trace(pkt->p_a1);
+        return ( holdself() );
+    }
+}
+
+void append(struct packet *pkt, struct packet *ptr)
+{
+    pkt->p_link = 0;
+
+    while ( ptr->p_link )
+        ptr = ptr->p_link;
+
+    ptr->p_link = pkt;
+}
+
+int bench(int inner) {
+    struct packet *wkq = 0;
+
+    createtask(I_IDLE, 0, wkq, S_RUN, idlefn, 1, Count);
+
+    wkq = pkt(0, 0, K_WORK);
+    wkq = pkt(wkq, 0, K_WORK);
+
+    createtask(I_WORK, 1000, wkq, S_WAITPKT, workfn, I_HANDLERA, 0);
+
+    wkq = pkt(0, I_DEVA, K_DEV);
+    wkq = pkt(wkq, I_DEVA, K_DEV);
+    wkq = pkt(wkq, I_DEVA, K_DEV);
+
+    createtask(I_HANDLERA, 2000, wkq, S_WAITPKT, handlerfn, 0, 0);
+
+    wkq = pkt(0, I_DEVB, K_DEV);
+    wkq = pkt(wkq, I_DEVB, K_DEV);
+    wkq = pkt(wkq, I_DEVB, K_DEV);
+
+    createtask(I_HANDLERB, 3000, wkq, S_WAITPKT, handlerfn, 0, 0);
+
+    wkq = 0;
+    createtask(I_DEVA, 4000, wkq, S_WAIT, devfn, 0, 0);
+    createtask(I_DEVB, 5000, wkq, S_WAIT, devfn, 0, 0);
+
+    tcb = tasklist;
+
+    qpktcount = holdcount = 0;
+
+    tracing = FALSE;
+    layout = 0;
+
+    schedule(inner);
+
+    return qpktcount;
+}
+
+
+int inner_loop(int inner) {
+    int r = 0;
+    while (inner > 0) {
+        r += bench(inner);
+        inner--;
+    }
+    return r;
+}
+
+int main(int argc, char* argv[])
+{
+    int iterations = DEFAULT_ITER;
+    int warmup     = 0;
+    int inner_iterations = 100;
+
+    parse_argv(argc, argv, &iterations, &warmup, &inner_iterations);
+
+    int result = 0;
+    while (iterations > 0) {
+        unsigned long start = microseconds();
+        result += inner_loop(inner_iterations);
+        unsigned long elapsed = microseconds() - start;
+        printf("Richards: iterations=1 runtime: %lu%s\n", elapsed, "us");
+        iterations--;
+    }
+}

--- a/mark.c
+++ b/mark.c
@@ -875,7 +875,7 @@ GC_INNER mse * GC_mark_from(mse *mark_stack_top, mse *mark_stack,
           for(;;) {
             GC_ASSERT((word)limit >= (word)current_p);
             if (cheri_address_get(limit) < cheri_base_get(limit)) goto next_object;
-  
+
             has_rwx = cheri_perms_get(limit) & (CHERI_PERM_LOAD
                                                 | CHERI_PERM_STORE
                                                 | CHERI_PERM_EXECUTE);


### PR DESCRIPTION
* Use a capability spanning the entire global `.data` section. If the spanning capability  cannot be derived directly from `*etext, edata, end*`, then probe the `.data` region using the read-only capability provided by by the `dl_iterate_phdr()` call to find scan the global roots. 

* Add the **richards** benchmark which was triggering the crash due to not scanning roots in global data to the test suite. 
