### PR TITLE
Use capability spanning .data section to scan global roots

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -943,7 +943,7 @@ EXTERN_C_BEGIN
 #   ifdef __ELF__
 #     define DYNAMIC_LOADING
 #   endif
-#   if !defined(ALPHA) && !defined(SPARC)
+#   if !defined(ALPHA) && !defined(SPARC) && !defined(RISCV)
       extern char etext[];
 #     define DATASTART GC_FreeBSDGetDataStart(0x1000, (ptr_t)etext)
 #     define DATASTART_USES_BSDGETDATASTART
@@ -2131,6 +2131,10 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef FREEBSD
       /* Nothing specific. */
+#     ifdef __CHERI_PURE_CAPABILITY__
+        extern char end[];
+#       define DATAEND ((ptr_t)end)
+#     endif
 #   endif
 #   ifdef NETBSD
 #     define ELF_CLASS ELFCLASS64
@@ -2489,9 +2493,10 @@ EXTERN_C_BEGIN
 #     if 0  //FIXME CHERI  - commented to simplify initial port
 #     define DYNAMIC_LOADING   
 #     endif 
-      extern char etext[];
-#     define DATASTART GC_FreeBSDGetDataStart(0x1000, (ptr_t)etext)
+      extern char etext, edata, end;
+#     define DATASTART GC_FreeBSDGetDataStart(0x1000, (ptr_t)&etext)
 #     define DATASTART_USES_BSDGETDATASTART
+#     define DATAEND ((ptr_t)(&end))
 #   endif
 #   ifdef LINUX
       extern int __data_start[] __attribute__((__weak__));

--- a/mark_rts.c
+++ b/mark_rts.c
@@ -167,10 +167,18 @@ GC_API void GC_CALL GC_add_roots(void *b, void *e)
 void GC_add_roots_inner(ptr_t b, ptr_t e, GC_bool tmp)
 {
     GC_ASSERT((word)b <= (word)e);
+# if defined(__CHERI_PURE_CAPABILITY__)
+    b = (ptr_t)cheri_align_up(b, WORDS_TO_BYTES(1));
+                                        /* round b up to word boundary */
+    e = (ptr_t)cheri_align_down(e, WORDS_TO_BYTES(1));
+                                        /* round e down to word boundary */
+# else
     b = (ptr_t)(((word)b + (sizeof(word) - 1)) & ~(word)(sizeof(word) - 1));
                                         /* round b up to word boundary */
     e = (ptr_t)((word)e & ~(word)(sizeof(word) - 1));
                                         /* round e down to word boundary */
+# endif
+
     if ((word)b >= (word)e) return; /* nothing to do */
 
 #   if defined(MSWIN32) || defined(MSWINCE) || defined(CYGWIN32)


### PR DESCRIPTION
Use a capability spanning the entire global .data section. If the spanning capability cannot be derived directly from *etext, edata, end*, then probe the .data region using the read-only capability provided by by the dl_iterate_phdr() call to find scan the global roots.