### PR TITLE
map dynamic library globals to root set

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -36,8 +36,9 @@ $ERROR && exit 1
 # One time setup per architecture
 setup() 
 {
+    HOST_INSTALL_PREFIX=${1:-bdwgc_install}
     # Copy library files to target VM
-    scp -o "StrictHostKeyChecking no" -P ${SSHPORT} bdwgc_install/lib/libgc.so.1.5.1 bdwgc_install/lib/libcord.so.1.5.0 root@${SSHHOST}:/root
+    scp -o "StrictHostKeyChecking no" -P ${SSHPORT} ${HOST_INSTALL_PREFIX}/lib/libgc.so.1.5.1 ${HOST_INSTALL_PREFIX}/lib/libcord.so.1.5.0 root@${SSHHOST}:/root
     if [ $? -ne 0 ]; then 
         echo "Error copying bdwgc library to ${BUILDBOT_PLATFORM} VM"
         exit 1
@@ -53,42 +54,66 @@ setup()
     fi 	
 }
 
-# arg-1 : compiled unit-test executable (with relative path)
-run()
+# arg-1 : OK - to obtain exit status from executing ssh cmd
+# arg-2 : compiled unit-test executable (with relative path)
+# arg-3 : benchmark library for shim executable if compiled with DYNAMIC_LOADING=ON
+run_single_bench()
 {
-    for name in "${@:2}"; do
-        echo "Transferring  ${name}"
-        scp -o "StrictHostKeyChecking no" -P ${SSHPORT} ${name}  root@${SSHHOST}:/root
-        if [ $? -ne 0 ]; then 
-            echo "Error copying unit-test executable ${name} to ${BUILDBOT_PLATFORM} VM"
+    FILES="${2} ${3}"
+    echo "Transferring  ${FILES}"
+    scp -o "StrictHostKeyChecking no" -P ${SSHPORT} ${FILES}  root@${SSHHOST}:/root
+    if [ $? -ne 0 ]; then
+        echo "Error copying unit-test executable ${name} to ${BUILDBOT_PLATFORM} VM"
+        exit 1
+    fi
+
+    # These tests should trigger an "In-address space security exception"
+    # So they should fail, i.e. `exit=1`
+    if [ "$1" == "to_fail" ]; then
+        exit_status=0
+        RESULT={{$(ssh -o "StrictHostKeyChecking no" -p ${SSHPORT} root@${SSHHOST} -t \
+	               "LD_LIBRARY_PATH=/root:\$\{LD_LIBRARY_PATH\} ./$(basename ${name})")} && exit_status=1} || true
+        if [ $exit_status -ne 0 ]; then
             exit 1
         fi
+    else
+        ssh -o "StrictHostKeyChecking no" -p ${SSHPORT} root@${SSHHOST} -t \
+	         "LD_LIBRARY_PATH=/root:\$\{LD_LIBRARY_PATH\} ./$(basename ${name})"
+    fi
+}
 
-        # These tests should trigger an "In-address space security exception"
-        # So they should fail, i.e. `exit=1`
-        if [ "$1" = "to_fail" ]; then
-            exit_status=0
-            RESULT={{$(ssh -o "StrictHostKeyChecking no" -p ${SSHPORT} root@${SSHHOST} -t \
-	                   "LD_LIBRARY_PATH=/root:\$\{LD_LIBRARY_PATH\} ./$(basename ${name})")} && exit_status=1} || true
-            if [ $exit_status != 0 ]; then
-                exit 1
-            fi
-        else
-            ssh -o "StrictHostKeyChecking no" -p ${SSHPORT} root@${SSHHOST} -t \
-	                   "LD_LIBRARY_PATH=/root:\$\{LD_LIBRARY_PATH\} ./$(basename ${name})"
-        fi
+# arg-1 : OK - to obtain exit status from executing ssh cmd
+# arg-2 : compiled unit-test executable (with relative path)
+run()
+{
+    DYNLIB=${2:-"no-dynlib"}
+    for name in "${@:3}"; do
+      if [ ${DYNLIB} == "dynlib" ]; then
+          INSTALLDIR=$(dirname ${name} | cut -d "/" -f1)
+          LIBROOT=$(basename ${name} .elf)
+          LIBNAME="${INSTALLDIR}/lib/lib${LIBROOT}_shim.so"
+          run_single_bench ${1} ${name} ${LIBNAME}
+      else
+          run_single_bench ${1} ${name}
+      fi
     done
 
 }
 
 # Copy bdwgc library and set up environment 
-setup
+setup "bdwgc_install"
 
 # Execute 
-run OK "bdwgc_install/bin/small_fixed_alloc.elf"  \
+run OK "no-dynlib" \
+       "bdwgc_install/bin/small_fixed_alloc.elf"  \
        "bdwgc_install/bin/random_mixed_alloc.elf" \
        "bdwgc_install/bin/smash_test.elf"         \
        "bdwgc_install/bin/leak.elf"               \
        "bdwgc_install/bin/binary_tree.elf"        \
        "bdwgc_install/bin/huge.elf"               \
-       "bdwgc_install/bin/richards.elf"           \
+       "bdwgc_install/bin/richards.elf"
+
+setup "bdwgc_install_dynlib"
+
+run OK "dynlib" \
+       "bdwgc_install_dynlib/bin/richards_dynlib.elf"

--- a/ci/tests/CMakeLists.txt
+++ b/ci/tests/CMakeLists.txt
@@ -6,22 +6,38 @@ project(BoehmGC
         LANGUAGES C)
 
 include_directories(AFTER ${CMAKE_INSTALL_PREFIX}/include) 
-add_executable(random_mixed_alloc.elf random_mixed_alloc.c)
-add_executable(small_fixed_alloc.elf small_fixed_alloc.c)
-add_executable(binary_tree.elf binary_tree.c)
-add_executable(smash_test.elf smash.c)
-add_executable(huge.elf huge.c)
-add_executable(leak.elf leak.c)
-add_executable(richards.elf richards.c)
-target_link_libraries(random_mixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
-target_link_libraries(small_fixed_alloc.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
-target_link_libraries(binary_tree.elf libm.so libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
-target_link_libraries(huge.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
-target_link_libraries(smash_test.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
-target_link_libraries(leak.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
-target_link_libraries(richards.elf libpthread.so ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
 
-install(TARGETS random_mixed_alloc.elf
+if (DEFINED BENCHLIB)
+    add_compile_definitions(BENCHLIB)
+    add_library(richards_dynlib_shim SHARED richards.c)
+    add_executable(richards_dynlib.elf dynlib_shim.c)
+    target_link_libraries(richards_dynlib.elf richards_dynlib_shim ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+else()
+    add_executable(random_mixed_alloc.elf random_mixed_alloc.c)
+    add_executable(small_fixed_alloc.elf small_fixed_alloc.c)
+    add_executable(binary_tree.elf binary_tree.c)
+    add_executable(smash_test.elf smash.c)
+    add_executable(huge.elf huge.c)
+    add_executable(leak.elf leak.c)
+    add_executable(richards.elf richards.c)
+
+    target_link_libraries(random_mixed_alloc.elf  ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+    target_link_libraries(small_fixed_alloc.elf ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+    target_link_libraries(binary_tree.elf m ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+    target_link_libraries(huge.elf ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+    target_link_libraries(smash_test.elf ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+    target_link_libraries(leak.elf ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+    target_link_libraries(richards.elf ${CMAKE_INSTALL_PREFIX}/lib/libgc.so)
+endif()
+
+
+if (DEFINED BENCHLIB)
+    install(TARGETS
+                richards_dynlib.elf richards_dynlib_shim
+                RUNTIME DESTINATION bin
+                LIBRARY DESTINATION lib)
+else()
+    install(TARGETS random_mixed_alloc.elf
                 small_fixed_alloc.elf
                 binary_tree.elf
                 huge.elf
@@ -29,3 +45,4 @@ install(TARGETS random_mixed_alloc.elf
                 leak.elf
                 richards.elf
                 RUNTIME DESTINATION bin)
+endif()

--- a/ci/tests/dynlib_shim.c
+++ b/ci/tests/dynlib_shim.c
@@ -1,0 +1,7 @@
+/* To be defined in a shared library */
+int bench_main(int argc, char *argv[]);
+
+int main(int argc, char *argv[])
+{
+  return bench_main(argc, argv);
+}

--- a/ci/tests/richards.c
+++ b/ci/tests/richards.c
@@ -421,7 +421,12 @@ int inner_loop(int inner) {
     return r;
 }
 
+#if !defined(BENCHLIB)
 int main(int argc, char* argv[])
+#else
+int bench_main(int argc, char* argv[])
+#endif
+
 {
     int iterations = DEFAULT_ITER;
     int warmup     = 0;

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -2146,6 +2146,12 @@ GC_INNER void GC_with_callee_saves_pushed(void (*fn)(ptr_t, void *),
                                                    | CHERI_PERM_EXECUTE);    \
             if (!in_bounds || !has_rwx) continue;                            \
         }
+
+# define SPANNING_CAPABILITY(cap, start, end) \
+      (cheri_tag_get((cap)) \
+        && cheri_base_get((cap)) <= (start)    \
+        && (cheri_base_get((cap)) + cheri_length_get((cap))) >= (end) \
+        && (cheri_perms_get((cap)) & (CHERI_PERM_LOAD|CHERI_PERM_LOAD_CAP)) != 0)
 #else
 # define LOAD_WORD_OR_CONTINUE(v, p) (void)(v = *(word *)(p))
 #endif /* !E2K */

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2338,9 +2338,7 @@ EXTERN_C_BEGIN
 #     define SIG_SUSPEND SIGUSR1
 #     define SIG_THR_RESTART SIGUSR2
 #     define FREEBSD_STACKBOTTOM
-#     if 0  //FIXME CHERI  - commented to simplify initial port
 #     define DYNAMIC_LOADING   
-#     endif 
       extern char etext, edata, end;
 #     define DATASTART GC_FreeBSDGetDataStart(0x1000, (ptr_t)&etext)
 #     define DATASTART_USES_BSDGETDATASTART

--- a/os_dep.c
+++ b/os_dep.c
@@ -2088,11 +2088,6 @@ void GC_register_data_segments(void)
         vaddr_t end;
         ptr_t  ld_cap;
     };
-#   define SPANNING_CAPABILITY(cap, start, end) \
-      (cheri_tag_get((cap)) \
-        && cheri_base_get((cap)) <= (start)    \
-        && (cheri_base_get((cap)) + cheri_length_get((cap))) >= (end) \
-        && (cheri_perms_get((cap)) & (CHERI_PERM_LOAD|CHERI_PERM_LOAD_CAP)) != 0)
 
     STATIC int GC_ld_cap_search(struct dl_phdr_info *info, size_t size, void *data)
     {


### PR DESCRIPTION
Add global data sections from dynamically linked libraries to mark stack when executing Garbage-Collection